### PR TITLE
Tryout

### DIFF
--- a/src/MyGroup.ts
+++ b/src/MyGroup.ts
@@ -20,7 +20,7 @@ class ExtendedGroup extends FabricGroup {
     super(
       objects,
       // Сохраняем начальные позиции группы
-      { ...rest, left: x ?? left, top: y ?? top, layout: "fixed-size" },
+      { ...rest, left: x ?? left, top: y ?? top, layout: "fit-size" },
       objectsRelativeToGroup
     );
   }
@@ -41,7 +41,7 @@ class ExtendedGroup extends FabricGroup {
   }
 
   onLayout() {
-    this.layout === "fixed-size" && this.setCoords();
+    this.layout === "fit-size" && this.setCoords();
     this.canvas?.requestRenderAll();
   }
 
@@ -57,7 +57,7 @@ class ExtendedGroup extends FabricGroup {
     objects: FabricObject[],
     context: LayoutContext
   ) {
-    if (layoutDirective === "fixed-size" && context.type !== "initialization") {
+    if (layoutDirective === "fit-size" && context.type !== "initialization") {
       const { width, height } = this.prepareBoundingBox(
         layoutDirective,
         objects,
@@ -74,7 +74,7 @@ class ExtendedGroup extends FabricGroup {
       }
     }
     return super.getLayoutStrategyResult(
-      layoutDirective === "fixed-size" ? "fixed" : layoutDirective,
+      layoutDirective === "fit-size" ? "fixed" : layoutDirective,
       objects,
       context
     );

--- a/src/MyGroup.ts
+++ b/src/MyGroup.ts
@@ -1,4 +1,4 @@
-import { Group as FabricGroup, Object as FabricObject } from 'fabric';
+import { Group as FabricGroup, Object as FabricObject } from "fabric";
 
 type FabricGroupParams = ConstructorParameters<typeof FabricGroup>;
 type GroupParams = FabricGroupParams[1];
@@ -11,12 +11,18 @@ class ExtendedGroup extends FabricGroup {
   x?: number;
   y?: number;
 
-  constructor(objects?: FabricGroupParams[0], options?: ExtendedGroupParams, objectsRelativeToGroup?: boolean) {
-    const { x, y, ...rest } = options || {};
-    super(objects, rest, objectsRelativeToGroup);
-    // Сохраняем начальные позиции группы
-    this.x = x || options?.left;
-    this.y = y || options?.top;
+  constructor(
+    objects?: FabricGroupParams[0],
+    options?: ExtendedGroupParams,
+    objectsRelativeToGroup?: boolean
+  ) {
+    const { x, y, left, top, ...rest } = options || {};
+    super(
+      objects,
+      // Сохраняем начальные позиции группы
+      { ...rest, left: x ?? left, top: y ?? top },
+      objectsRelativeToGroup
+    );
   }
 
   _onObjectAdded(obj: FabricObject): void {
@@ -30,7 +36,27 @@ class ExtendedGroup extends FabricGroup {
     // obj.setCoords();
 
     // eslint-disable-next-line no-underscore-dangle
-    super._onObjectAdded(obj);
+    super._onRelativeObjectAdded(obj);
+  }
+
+  onLayout() {
+    this.canvas?.requestRenderAll();
+  }
+
+  getLayoutStrategyResult1<T extends this["layout"]>(
+    layoutDirective: T,
+    objects: FabricObject[],
+    context: LayoutContext
+  ) {
+    console.log(context.type);
+    if (layoutDirective === "fixed" && context.type === "added") {
+      console.log(objects);
+      const { width, height, ...rest } = this.getObjectsBoundingBox(objects);
+
+      console.log(width, height, rest);
+      return { width: 100, height: 100, centerX: 100, centerY: 100 };
+    }
+    return super.getLayoutStrategyResult(layoutDirective, objects, context);
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
-import { Canvas, Group, Point, Line, Circle } from "fabric";
+import { Canvas, Point, Line, Circle, Shadow } from "fabric";
+import Group from "./MyGroup";
 import "./styles.css";
 
 // We have a React Wrapper library (see a separate pdf file)
@@ -23,35 +24,18 @@ canvas.add(
 const group1 = new Group([], {
   left: 100,
   top: 100,
-  // originX: "center",
   layout: "fixed",
-  // for testing
-  // subTargetCheck: true,
-  // interactive: true,
 }); // group is created in useFarbicObject hook
 
-// ExtendedCanvas._onObjectAdded (we redefine this method to update coordinates)
 canvas.add(group1); // add created object (that is - group1) to canvas
-// group1.setXY(new Point(100, 100)); // update coordinates
-// group1.setCoords();
-// group1.triggerLayout();
-// canvas.requestRenderAll();
 
 // <Group defaultOptions={{ originX: 'center' }} >
 const group2 = new Group([], {
   originX: "center",
-  // for testing
-  // subTargetCheck: true,
-  // interactive: true,
+  layout: "fixed",
 }); // group is created in useFarbicObject hook
 
-// ExtendedGroup._onObjectAdded (and redefine method of Group as well)
-// group1.triggerLayout();
 group1.add(group2); // add created object (that is - group2) to group
-// group2.setXY(new Point(100, 100));
-// group2.setCoords();
-// group2.triggerLayout();
-canvas.requestRenderAll();
 
 // <Circle
 //   defaultOptions={{
@@ -68,19 +52,12 @@ const circle1 = new Circle({
   // circle is created in useFarbicObject hook
   radius: 50,
   fill: "white",
-  shadow: "0 2 4 #d9d9d9",
+  shadow: new Shadow("0 2 4 #d9d9d9"),
   originX: "center",
   originY: "center",
-  left: 100,
-  top: 100,
 });
 
-// ExtendedGroup._onObjectAdded
 group2.add(circle1);
-// circle1.setXY(new Point(100, 100)); // we set absolute coordinates
-// circle1.setCoords();
-// group2.triggerLayout();
-canvas.requestRenderAll();
 
 // <Circle
 //   defaultOptions={{
@@ -101,20 +78,14 @@ const circle2 = new Circle({
   fill: "transparent",
   stroke: "#E37566",
   strokeWidth: 6,
-  shadow: "0 2 4 #d9d9d9",
+  shadow: new Shadow("0 2 4 #d9d9d9"),
   originX: "center",
   originY: "center",
-  left: 100,
-  top: 100,
 });
 
-// ExtendedGroup._onObjectAdded
 group2.add(circle2);
-// circle2.setXY(new Point(100, 100)); // we set absolute coordinates
-// circle2.setCoords();
-group1.triggerLayout();
-group1.setCoords();
-canvas.requestRenderAll();
+
+group2.triggerLayout(/*{ layout: "fit-content" }*/);
 
 // canvas.setActiveObject(group1);
-window.canvas = canvas;
+// window.canvas = canvas;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,41 +1,43 @@
-import {
-  Canvas, Group, Point, Line, Circle
-}  from 'fabric';
-import './styles.css';
+import { Canvas, Group, Point, Line, Circle } from "fabric";
+import "./styles.css";
 
 // We have a React Wrapper library (see a separate pdf file)
 // In this file we repeated the calls of FabricJS methods
 
 // When we render <Canvas> FarbicJS canvas is created and initialized
-const canvas = new Canvas('canvas1', {
-  backgroundColor: '#F8F8F8',
+const canvas = new Canvas("canvas1", {
+  backgroundColor: "#F8F8F8",
   width: 800,
   height: 600,
 });
 
 // This is just for visualization (not part of problem :-)
-canvas.add(new Line([0, 100, 800, 100], { stroke: 'lightgrey', strokeWidth: 1 }));
-canvas.add(new Line([100, 0, 100, 600], { stroke: 'lightgrey', strokeWidth: 1 }));
+canvas.add(
+  new Line([0, 100, 800, 100], { stroke: "lightgrey", strokeWidth: 1 })
+);
+canvas.add(
+  new Line([100, 0, 100, 600], { stroke: "lightgrey", strokeWidth: 1 })
+);
 
-// <Group defaultOptions={{ x: 100, y: 100 }}> 
-const group1 = new Group([]); // group is created in useFarbicObject hook
+// <Group defaultOptions={{ x: 100, y: 100 }}>
+const group1 = new Group([], { left: 100, top: 100, layout: "fixed" }); // group is created in useFarbicObject hook
 
 // ExtendedCanvas._onObjectAdded (we redefine this method to update coordinates)
 canvas.add(group1); // add created object (that is - group1) to canvas
-group1.setXY(new Point(100, 100)); // update coordinates
-group1.setCoords();
-group1.triggerLayout();
-canvas.requestRenderAll();
+// group1.setXY(new Point(100, 100)); // update coordinates
+// group1.setCoords();
+// group1.triggerLayout();
+// canvas.requestRenderAll();
 
 // <Group defaultOptions={{ originX: 'center' }} >
-const group2 = new Group([], { originX: 'center' }); // group is created in useFarbicObject hook
+const group2 = new Group([], { originX: "center" }); // group is created in useFarbicObject hook
 
 // ExtendedGroup._onObjectAdded (and redefine method of Group as well)
-group1.triggerLayout();
+// group1.triggerLayout();
 group1.add(group2); // add created object (that is - group2) to group
-group2.setXY(new Point(100, 100));
-group2.setCoords();
-group2.triggerLayout();
+// group2.setXY(new Point(100, 100));
+// group2.setCoords();
+// group2.triggerLayout();
 canvas.requestRenderAll();
 
 // <Circle
@@ -49,19 +51,22 @@ canvas.requestRenderAll();
 //     originY: 'center'
 //   }}
 // />
-const circle1 = new Circle({ // circle is created in useFarbicObject hook
+const circle1 = new Circle({
+  // circle is created in useFarbicObject hook
   radius: 50,
-  fill: 'white',
-  shadow: '0 2 4 #d9d9d9',
-  originX: 'center',
-  originY: 'center'
+  fill: "white",
+  shadow: "0 2 4 #d9d9d9",
+  originX: "center",
+  originY: "center",
+  left: 100,
+  top: 100,
 });
 
 // ExtendedGroup._onObjectAdded
 group2.add(circle1);
-circle1.setXY(new Point(100, 100)); // we set absolute coordinates
-circle1.setCoords();
-group2.triggerLayout();
+// circle1.setXY(new Point(100, 100)); // we set absolute coordinates
+// circle1.setCoords();
+// group2.triggerLayout();
 canvas.requestRenderAll();
 
 // <Circle
@@ -77,14 +82,15 @@ canvas.requestRenderAll();
 //     originY: 'center'
 //   }}
 // />
-const circle2 = new Circle({ // circle is created in useFarbicObject hook
+const circle2 = new Circle({
+  // circle is created in useFarbicObject hook
   radius: 42,
-  fill: 'transparent',
-  stroke: '#E37566',
+  fill: "transparent",
+  stroke: "#E37566",
   strokeWidth: 6,
-  shadow: '0 2 4 #d9d9d9',
-  originX: 'center',
-  originY: 'center'
+  shadow: "0 2 4 #d9d9d9",
+  originX: "center",
+  originY: "center",
 });
 
 // ExtendedGroup._onObjectAdded

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,15 +24,14 @@ canvas.add(
 const group1 = new Group([], {
   left: 100,
   top: 100,
-  layout: "fixed",
 }); // group is created in useFarbicObject hook
 
 canvas.add(group1); // add created object (that is - group1) to canvas
 
-// <Group defaultOptions={{ originX: 'center' }} >
+// <Group defaultOptions={{ }} >
 const group2 = new Group([], {
   originX: "center",
-  layout: "fixed",
+  originY: "center",
 }); // group is created in useFarbicObject hook
 
 group1.add(group2); // add created object (that is - group2) to group
@@ -84,8 +83,6 @@ const circle2 = new Circle({
 });
 
 group2.add(circle2);
-
-group2.triggerLayout(/*{ layout: "fit-content" }*/);
 
 // canvas.setActiveObject(group1);
 // window.canvas = canvas;

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,15 @@ canvas.add(
 );
 
 // <Group defaultOptions={{ x: 100, y: 100 }}>
-const group1 = new Group([], { left: 100, top: 100, layout: "fixed" }); // group is created in useFarbicObject hook
+const group1 = new Group([], {
+  left: 100,
+  top: 100,
+  // originX: "center",
+  layout: "fixed",
+  // for testing
+  // subTargetCheck: true,
+  // interactive: true,
+}); // group is created in useFarbicObject hook
 
 // ExtendedCanvas._onObjectAdded (we redefine this method to update coordinates)
 canvas.add(group1); // add created object (that is - group1) to canvas
@@ -30,7 +38,12 @@ canvas.add(group1); // add created object (that is - group1) to canvas
 // canvas.requestRenderAll();
 
 // <Group defaultOptions={{ originX: 'center' }} >
-const group2 = new Group([], { originX: "center" }); // group is created in useFarbicObject hook
+const group2 = new Group([], {
+  originX: "center",
+  // for testing
+  // subTargetCheck: true,
+  // interactive: true,
+}); // group is created in useFarbicObject hook
 
 // ExtendedGroup._onObjectAdded (and redefine method of Group as well)
 // group1.triggerLayout();
@@ -91,11 +104,17 @@ const circle2 = new Circle({
   shadow: "0 2 4 #d9d9d9",
   originX: "center",
   originY: "center",
+  left: 100,
+  top: 100,
 });
 
 // ExtendedGroup._onObjectAdded
 group2.add(circle2);
-circle2.setXY(new Point(100, 100)); // we set absolute coordinates
-circle2.setCoords();
-group2.triggerLayout();
+// circle2.setXY(new Point(100, 100)); // we set absolute coordinates
+// circle2.setCoords();
+group1.triggerLayout();
+group1.setCoords();
 canvas.requestRenderAll();
+
+// canvas.setActiveObject(group1);
+window.canvas = canvas;


### PR DESCRIPTION
- There is no doubt there are several bugs in the layout mechanism involving originXY in fabric.
- I don't understand the need for `group1` but since this is a simplified example I am sure there is a need.

---

I have created something that works but feels fragile and insufficient for all cases. So I am not sure it is a good solution. Indeed the bugs need fixing, but for now this might be good enough.
Take a look and tell me if it is.
Seems to me you are looking for a custom `fixed` layout.
`fixed` layout means the group runs a layout only on initialization or when called explicitly by `triggerLayout` so adding/removing objects doesn't affect its size/position.
However, you want the size of the group to change when objects are added while keeping the same position.
So I introduced `fit-size` which does that.
Note that calling `triggerLayout` calls `setCoords` internally.


---

I thought of a different approach for the group react wrapper.
I thought it should be constructed only after its children are ready, but then you have to propagate the position to each child in initialization (and that is not what you really want).


